### PR TITLE
Align report parity: momentum, T-bill assumptions, and dashboard section fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Educational Python implementation of a simple ETF momentum rotation strategy int
 
 - **Universe:** `SPY`, `QQQ`, `TLT`, `DBC`, `GLD`
 - **Rebalance cadence:** Monthly
-- **Signal 1 (Ranking):** Select top 3 assets by **6-month momentum** (approx. 126 trading days total return)
+- **Signal 1 (Ranking):** Select top 3 assets by **6-calendar-month momentum** (month-end to month-end, prior-trading-day fallback on holidays/weekends)
 - **Signal 2 (Trend filter):** For each selected asset, require price > **135 trading day SMA**
 - **Cash sleeve:** If a selected asset fails the SMA filter, that sleeve remains in cash
 
@@ -90,11 +90,11 @@ Backtest/report assumptions implemented:
 - Simulation window: `2007-01-01` through end of the last completed month (inclusive, trading-calendar aware)
 - Adjusted prices via `yfinance` with `auto_adjust=True`
 - Rebalance: month-end close
-- Signal: top-3 by 126-trading-day momentum
+- Signal: top-3 by 6-calendar-month momentum (month-end anchored)
 - Trend filter: 135-trading-day SMA (`price > SMA135`)
 - Sleeve-to-cash behavior when SMA fails
 - Benchmarks: universe equal-weight (monthly rebalanced) + `VFINX`
-- Cash return assumption: 0.00% annualized
+- Cash + Risk-Free convention: FRED `DGS3MO` (3-Month Treasury Bill, secondary market), converted to monthly yield as `annual_yield/12` and compounded within month
 
 ## GitHub Actions monthly refresh
 

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -193,12 +193,12 @@ def simulate(prices: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, list[Reb
     return rets, drawdown, decisions, rf_monthly_annualized
 
 
-def annualized_return(r: pd.Series) -> float:
+def annualized_return(r: pd.Series, periods_per_year: int = 252) -> float:
     n = len(r)
     if n == 0:
         return np.nan
     total = (1 + r).prod()
-    return total ** (252 / n) - 1
+    return total ** (periods_per_year / n) - 1
 
 
 def annualized_vol(r: pd.Series) -> float:
@@ -299,7 +299,7 @@ def risk_analytics_table(rets: pd.DataFrame, rf_monthly_annualized: pd.Series, m
         ir = np.nan if te == 0 else (tracking.mean() * 12) / te
 
         mean_ann = annualized_return(rets[c].dropna())
-        rf_ann = annualized_return(rf_monthly.reindex(aligned.index).dropna())
+        rf_ann = annualized_return(rf_monthly.reindex(aligned.index).dropna(), periods_per_year=12)
         treynor = np.nan if pd.isna(beta) or beta == 0 or pd.isna(rf_ann) else (mean_ann - rf_ann) / beta
 
         var95 = aligned["asset"].quantile(0.05)

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -504,9 +504,9 @@ function traces(kind){{
   return Object.keys(data[kind]).map(k => ({{x:data.dates,y:data[kind][k],name:k,type:'scatter',mode:'lines'}}));
 }}
 Plotly.newPlot('equity', traces('equity'), {{paper_bgcolor:'rgba(0,0,0,0)',plot_bgcolor:'rgba(0,0,0,0)',font:{{color:getComputedStyle(document.body).getPropertyValue('--text')}}}});
-Plotly.newPlot('dd', traces('drawdown'), {paper_bgcolor:'rgba(0,0,0,0)',plot_bgcolor:'rgba(0,0,0,0)',font:{color:getComputedStyle(document.body).getPropertyValue('--text')},yaxis:{tickformat:'.0%'}});
-const roll = Object.keys(data.equity).map(k => ({x:data.dates,y:data.equity[k].map((_,i,a)=> i<252?null:(a[i]/a[i-252]-1)),name:k,type:'scatter',mode:'lines'}));
-Plotly.newPlot('rolling12', roll, {paper_bgcolor:'rgba(0,0,0,0)',plot_bgcolor:'rgba(0,0,0,0)',font:{color:getComputedStyle(document.body).getPropertyValue('--text')},yaxis:{tickformat:'.0%'}});
+Plotly.newPlot('dd', traces('drawdown'), {{paper_bgcolor:'rgba(0,0,0,0)',plot_bgcolor:'rgba(0,0,0,0)',font:{{color:getComputedStyle(document.body).getPropertyValue('--text')}},yaxis:{{tickformat:'.0%'}}}});
+const roll = Object.keys(data.equity).map(k => ({{x:data.dates,y:data.equity[k].map((_,i,a)=> i<252?null:(a[i]/a[i-252]-1)),name:k,type:'scatter',mode:'lines'}}));
+Plotly.newPlot('rolling12', roll, {{paper_bgcolor:'rgba(0,0,0,0)',plot_bgcolor:'rgba(0,0,0,0)',font:{{color:getComputedStyle(document.body).getPropertyValue('--text')}},yaxis:{{tickformat:'.0%'}}}});
 function toggleTheme(){{
   document.documentElement.classList.toggle('light');
   localStorage.setItem('theme', document.documentElement.classList.contains('light')?'light':'dark');

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -299,7 +299,8 @@ def risk_analytics_table(rets: pd.DataFrame, rf_monthly_annualized: pd.Series, m
         ir = np.nan if te == 0 else (tracking.mean() * 12) / te
 
         mean_ann = annualized_return(rets[c].dropna())
-        treynor = np.nan if pd.isna(beta) or beta == 0 else (mean_ann - RISK_FREE_ANNUAL) / beta
+        rf_ann = annualized_return(rf_monthly.reindex(aligned.index).dropna())
+        treynor = np.nan if pd.isna(beta) or beta == 0 or pd.isna(rf_ann) else (mean_ann - rf_ann) / beta
 
         var95 = aligned["asset"].quantile(0.05)
         cvar95 = aligned.loc[aligned["asset"] <= var95, "asset"].mean()
@@ -476,7 +477,7 @@ small{{color:var(--muted);}}
   </section>
 
   <section class=\"card\"><h3>Performance Summary</h3>{html_table(metrics_disp)}</section>
-  <section class=\"card\"><h3>Performance Summary</h3><div id=\"equity\" style=\"height:420px\"></div>{html_table(metrics_disp)}</section>
+  <section class=\"card\"><h3>Cumulative Returns</h3><div id=\"equity\" style=\"height:420px\"></div></section>
   <section class=\"card\"><h3>Annual Returns</h3>{html_table(yearly, percent_cols=set(yearly.columns))}</section>
   <section class=\"card\"><h3>Monthly Returns</h3>{html_table(month, percent_cols=set(month.columns))}</section>
   <section class=\"card\"><h3>Drawdown Analysis</h3><div id=\"dd\" style=\"height:340px\"></div>{html_table(risk_disp)}</section>

--- a/strategy.py
+++ b/strategy.py
@@ -4,7 +4,7 @@
 Rules:
 - Universe: SPY, QQQ, TLT, DBC, GLD
 - Monthly rebalance
-- Top 3 by 6-month momentum (126 trading day return)
+- Top 3 by 6-calendar-month momentum (month-end anchored with prior-trading-day fallback)
 - 135 trading day SMA filter per selected asset
 - Failed sleeves remain cash
 

--- a/strategy.py
+++ b/strategy.py
@@ -30,7 +30,7 @@ from alpaca.trading.requests import MarketOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 
 UNIVERSE = ["SPY", "QQQ", "TLT", "DBC", "GLD"]
-MOMENTUM_LOOKBACK_TRADING_DAYS = 126  # ~6 months
+MOMENTUM_LOOKBACK_MONTHS = 6
 SMA_WINDOW = 135
 TOP_N = 3
 
@@ -72,7 +72,7 @@ def get_trading_client() -> TradingClient:
 
 def required_lookback_trading_days() -> int:
     # Need one extra bar for pct_change plus enough bars for SMA.
-    return max(SMA_WINDOW, MOMENTUM_LOOKBACK_TRADING_DAYS + 1)
+    return max(SMA_WINDOW, 150)
 
 
 def trading_days_to_calendar_days(trading_days: int, extra_calendar_buffer: int = 21) -> int:
@@ -102,24 +102,44 @@ def fetch_prices(symbols: List[str], period_days: int) -> pd.DataFrame:
     return closes
 
 
+
+
+def price_on_or_before(series: pd.Series, target_date: pd.Timestamp) -> float | None:
+    hist = series.loc[:target_date].dropna()
+    if hist.empty:
+        return None
+    return float(hist.iloc[-1])
+
+
+def six_calendar_month_momentum(series: pd.Series, as_of: pd.Timestamp) -> float | None:
+    current = price_on_or_before(series, as_of)
+    lookback_target = as_of - pd.DateOffset(months=MOMENTUM_LOOKBACK_MONTHS)
+    lookback = price_on_or_before(series, lookback_target)
+    if current is None or lookback is None or lookback == 0:
+        return None
+    return current / lookback - 1.0
+
 def compute_signals(closes: pd.DataFrame, as_of: str | None = None) -> List[SignalRow]:
     if as_of:
         as_of_dt = pd.Timestamp(as_of)
         closes = closes.loc[:as_of_dt]
 
-    if len(closes) < max(SMA_WINDOW, MOMENTUM_LOOKBACK_TRADING_DAYS) + 1:
+    if len(closes) < SMA_WINDOW + 1:
         raise RuntimeError("Not enough history to compute momentum and SMA")
 
     latest = closes.iloc[-1]
-    momentum = closes.pct_change(MOMENTUM_LOOKBACK_TRADING_DAYS).iloc[-1]
     sma = closes.rolling(SMA_WINDOW).mean().iloc[-1]
 
     rows: List[SignalRow] = []
+    as_of_dt = closes.index[-1]
     for symbol in UNIVERSE:
+        series = closes[symbol].dropna()
+        m = six_calendar_month_momentum(series, as_of_dt)
+        if m is None:
+            continue
         c = float(latest[symbol])
-        m = float(momentum[symbol])
         s = float(sma[symbol])
-        rows.append(SignalRow(symbol=symbol, close=c, momentum_6m=m, sma_135=s, passes_sma=c > s))
+        rows.append(SignalRow(symbol=symbol, close=c, momentum_6m=float(m), sma_135=s, passes_sma=c > s))
 
     rows.sort(key=lambda x: x.momentum_6m, reverse=True)
     return rows
@@ -139,7 +159,7 @@ def build_target_weights(signal_rows: List[SignalRow]) -> Dict[str, float]:
 
 
 def print_signal_table(rows: List[SignalRow]) -> None:
-    logging.info("Signal table (sorted by 6m momentum):")
+    logging.info("Signal table (sorted by 6-calendar-month momentum):")
     for r in rows:
         logging.info(
             "%s | close=%.2f | mom6m=%+.2f%% | sma135=%.2f | pass=%s",


### PR DESCRIPTION
## Summary
This PR closes a linked parity batch spanning #3, #4, and #6 because the implementation touches a single simulation/reporting pipeline.

### What changed
- Implemented **6-calendar-month momentum** logic (month-end anchored with prior-trading-day fallback).
- Replaced zero cash/risk-free assumptions with **FRED DGS3MO** convention for both cash sleeve and risk metrics.
- Updated dashboard section flow and labels to mirror requested report ordering/terminology:
  1. Strategy Overview
  2. Performance Summary
  3. Annual Returns
  4. Monthly Returns
  5. Drawdown Analysis
  6. Rolling Returns
  7. Exposure/Holdings

### Notes
- Could not execute full dashboard build in this environment because project dependencies are not installed (`ModuleNotFoundError: No module named 'numpy'`).
- Python syntax checks pass for modified files.

## Linked issues
- Closes #3
- Closes #4
- Closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard Strategy Overview added; metric cards relabeled (e.g., Maximum Drawdown).
  * Dashboard and metrics now use monthly 3‑Month T‑Bill as the risk‑free series.

* **Bug Fixes**
  * Risk‑adjusted metrics (Sharpe, Sortino, Treynor) align correctly with monthly/daily risk‑free inputs.
  * Momentum calculation handles missing data and avoids invalid computations.

* **Documentation**
  * Momentum methodology updated to a 6‑calendar‑month basis with month‑end anchoring and prior‑trading‑day fallback.
  * Cash/return convention clarified to use market 3‑Month T‑Bill conversions; SMA filter and lookback wording updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->